### PR TITLE
core: allow runnable types in agent executor

### DIFF
--- a/libs/langchain/langchain/agents/agent.py
+++ b/libs/langchain/langchain/agents/agent.py
@@ -915,7 +915,7 @@ NextStepOutput = List[Union[AgentFinish, AgentAction, AgentStep]]
 class AgentExecutor(Chain):
     """Agent that is using tools."""
 
-    agent: Union[BaseSingleActionAgent, BaseMultiActionAgent]
+    agent: Union[BaseSingleActionAgent, BaseMultiActionAgent, RunnableAgent, Runnable]
     """The agent to run for creating a plan and determining actions
     to take at each step of the execution loop."""
     tools: Sequence[BaseTool]
@@ -960,7 +960,7 @@ class AgentExecutor(Chain):
     @classmethod
     def from_agent_and_tools(
         cls,
-        agent: Union[BaseSingleActionAgent, BaseMultiActionAgent],
+        agent: Union[BaseSingleActionAgent, BaseMultiActionAgent, RunnableAgent, Runnable],
         tools: Sequence[BaseTool],
         callbacks: Callbacks = None,
         **kwargs: Any,


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [x] **PR title**: "package: description"

- [x] **PR message**:
Allow Runnable types in `AgentExecutor`. Addresses https://github.com/langchain-ai/langchain/issues/13075. Also seems to make sense with deprecation of agent classes like `OpenAIFunctionsAgent` in favor of functions that return runnables like `create_openai_functions_agent`

- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, hwchase17.
